### PR TITLE
Fix vite server options typing

### DIFF
--- a/server/vite.ts
+++ b/server/vite.ts
@@ -1,7 +1,7 @@
 import express, { type Express } from "express";
 import fs from "fs";
 import path from "path";
-import { createServer as createViteServer, createLogger } from "vite";
+import { createServer as createViteServer, createLogger, type ServerOptions } from "vite";
 import { type Server } from "http";
 import viteConfig from "../vite.config";
 import { nanoid } from "nanoid";
@@ -20,7 +20,7 @@ export function log(message: string, source = "express") {
 }
 
 export async function setupVite(app: Express, server: Server) {
-  const serverOptions = {
+  const serverOptions: ServerOptions = {
     middlewareMode: true,
     hmr: { server },
     allowedHosts: true,


### PR DESCRIPTION
## Summary
- fix server options typing for vite dev server

## Testing
- `npm run check` *(fails: Property 'leadSubmissions' does not exist on type 'DatabaseStorage' etc.)*

------
https://chatgpt.com/codex/tasks/task_e_684c6d3eecdc832383dbf66c42aed3ee