### PR TITLE
Fix apiRequest argument order

### DIFF
--- a/client/src/components/apartment-finder.tsx
+++ b/client/src/components/apartment-finder.tsx
@@ -38,7 +38,7 @@ export default function ApartmentFinder() {
         ...data,
         moveInDate: data.moveInDate ? new Date(data.moveInDate) : null,
       };
-      const response = await apiRequest("POST", "/api/lead-submissions", submitData);
+      const response = await apiRequest("/api/lead-submissions", "POST", submitData);
       return response.json();
     },
     onSuccess: () => {


### PR DESCRIPTION
## Summary
- update `apiRequest` call in apartment finder to pass URL first and method second

## Testing
- `npm run check` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_e_684c702ebefc8323977ae43fd1faf9f8