### PR TITLE
Fix photo size limit docs

### DIFF
--- a/photos/README.md
+++ b/photos/README.md
@@ -27,7 +27,7 @@ Add photos showing:
 - JPEG (.jpg, .jpeg)
 - PNG (.png)
 - WebP (.webp)
-- Maximum recommended size: 2MB per image
+- Maximum recommended size: 20MB per image
 
 ### 5. Naming Convention
 Use descriptive names:

--- a/photos/properties/atlanta-253-14th-street-apartments/README.md
+++ b/photos/properties/atlanta-253-14th-street-apartments/README.md
@@ -14,7 +14,7 @@
 
 ## File Requirements
 - Formats: JPG, PNG, WebP
-- Max size: 5MB per image
+- Max size: 20MB per image
 - Descriptive names recommended
 
 Photos will automatically appear in property listings and unit details.


### PR DESCRIPTION
## Summary
- document 20MB photo limit in main instructions
- update property-specific README with same limit

## Testing
- `npm run check` *(fails: Cannot find name etc.)*

------
https://chatgpt.com/codex/tasks/task_e_684c703f69d8832387fface4e2edfe5c