### PR TITLE
Add automatic geocoding and cleanup map markers

### DIFF
--- a/client/src/components/map-section.tsx
+++ b/client/src/components/map-section.tsx
@@ -126,11 +126,6 @@ export default function MapSection({ cityFilter, setCityFilter, availabilityFilt
     // Clear existing markers
     const markers: any[] = [];
 
-    // Default coordinates for properties that don't have lat/lng
-    const defaultCoordinates = {
-      "The Loft District": { lat: 33.7701, lng: -84.3870 },
-      "Skyline Studios": { lat: 32.7767, lng: -96.7970 },
-    };
 
     // Filter properties based on city selection
     const filteredProperties = cityFilter === "all" 
@@ -144,22 +139,11 @@ export default function MapSection({ cityFilter, setCityFilter, availabilityFilt
         });
 
     filteredProperties.forEach((property) => {
-      let lat, lng;
-      
-      // Use stored coordinates if available, otherwise use defaults
-      if (property.latitude && property.longitude) {
-        lat = parseFloat(property.latitude);
-        lng = parseFloat(property.longitude);
-      } else {
-        const coords = defaultCoordinates[property.name as keyof typeof defaultCoordinates];
-        if (coords) {
-          lat = coords.lat;
-          lng = coords.lng;
-        } else {
-          // Skip properties without coordinates
-          return;
-        }
+      if (!property.latitude || !property.longitude) {
+        return;
       }
+      const lat = parseFloat(property.latitude);
+      const lng = parseFloat(property.longitude);
 
       const marker = new window.google.maps.Marker({
         position: { lat, lng },

--- a/server/geocode.ts
+++ b/server/geocode.ts
@@ -1,0 +1,24 @@
+export interface GeoResult {
+  lat: string;
+  lon: string;
+}
+
+export async function geocodeAddress(address: string): Promise<GeoResult | null> {
+  const key = process.env.GOOGLE_GEOCODING_API_KEY || process.env.VITE_GOOGLE_API_KEY;
+  if (!key) return null;
+
+  try {
+    const url =
+      `https://maps.googleapis.com/maps/api/geocode/json?address=${encodeURIComponent(address)}&key=${key}`;
+    const res = await fetch(url);
+    if (!res.ok) return null;
+    const data = await res.json();
+    if (data.status === 'OK' && Array.isArray(data.results) && data.results.length > 0) {
+      const { lat, lng } = data.results[0].geometry.location;
+      return { lat: String(lat), lon: String(lng) };
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "include": ["client/src/**/*", "shared/**/*", "server/**/*"],
-  "exclude": ["node_modules", "build", "dist", "**/*.test.ts"],
+  "exclude": ["node_modules", "build", "dist", "**/*.test.ts", "server/storage-backup.ts", "client/src/pages/admin-backup.tsx"],
   "compilerOptions": {
     "incremental": true,
     "tsBuildInfoFile": "./node_modules/typescript/tsbuildinfo",


### PR DESCRIPTION
## Summary
- add geocoding helper using Nominatim
- geocode on property create/update and populate missing coords at startup
- remove default coordinates and skip markers without lat/lng
- ignore backup files during TypeScript checks
- switch geocoding helper to use Google Maps API

## Testing
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_684c6fc0b9d883238e682f7d2375a8f9