### PR TITLE
Fix map coordinates

### DIFF
--- a/client/src/components/map-section.tsx
+++ b/client/src/components/map-section.tsx
@@ -142,8 +142,13 @@ export default function MapSection({ cityFilter, setCityFilter, availabilityFilt
       if (!property.latitude || !property.longitude) {
         return;
       }
+
       const lat = parseFloat(property.latitude);
       const lng = parseFloat(property.longitude);
+
+      if (Number.isNaN(lat) || Number.isNaN(lng)) {
+        return;
+      }
 
       const marker = new window.google.maps.Marker({
         position: { lat, lng },

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -16,7 +16,9 @@ async function populateMissingCoordinates() {
   try {
     const props = await storage.getProperties();
     for (const prop of props) {
-      if (!prop.latitude || !prop.longitude) {
+      const lat = prop.latitude ? parseFloat(prop.latitude) : NaN;
+      const lon = prop.longitude ? parseFloat(prop.longitude) : NaN;
+      if (!prop.latitude || !prop.longitude || Number.isNaN(lat) || Number.isNaN(lon)) {
         const addr = `${prop.address}, ${prop.city}, ${prop.state} ${prop.zipCode}`;
         const geo = await geocodeAddress(addr);
         if (geo) {
@@ -103,9 +105,12 @@ export async function registerRoutes(app: Express): Promise<Server> {
 
   app.post("/api/properties", isAuthenticated, async (req, res) => {
     try {
-      const validatedData = insertPropertySchema.parse(req.body);
+      const validatedData = insertPropertySchema.parse(req.body) as any;
 
-      if (!validatedData.latitude || !validatedData.longitude) {
+      const lat = validatedData.latitude ? parseFloat(validatedData.latitude) : NaN;
+      const lon = validatedData.longitude ? parseFloat(validatedData.longitude) : NaN;
+
+      if (!validatedData.latitude || !validatedData.longitude || Number.isNaN(lat) || Number.isNaN(lon)) {
         const addr = `${validatedData.address}, ${validatedData.city}, ${validatedData.state} ${validatedData.zipCode}`;
         const geo = await geocodeAddress(addr);
         if (geo) {
@@ -127,10 +132,13 @@ export async function registerRoutes(app: Express): Promise<Server> {
   app.put("/api/properties/:id", isAuthenticated, async (req, res) => {
     try {
       const id = parseInt(req.params.id);
-      const validatedData = insertPropertySchema.partial().parse(req.body);
+      const validatedData = insertPropertySchema.partial().parse(req.body) as any;
+
+      const lat = validatedData.latitude ? parseFloat(validatedData.latitude) : NaN;
+      const lon = validatedData.longitude ? parseFloat(validatedData.longitude) : NaN;
 
       if (
-        (!validatedData.latitude || !validatedData.longitude) &&
+        (!validatedData.latitude || !validatedData.longitude || Number.isNaN(lat) || Number.isNaN(lon)) &&
         (validatedData.address || validatedData.city || validatedData.state || validatedData.zipCode)
       ) {
         const prop = await storage.getProperty(id);


### PR DESCRIPTION
## Summary
- handle invalid coordinates when rendering map markers
- sanitize lat/lon values when creating and updating properties
- re-geocode properties that have invalid coordinates

## Testing
- `npm run check`
- `npm test` *(fails: Environment variable REPLIT_DOMAINS not provided)*

------
https://chatgpt.com/codex/tasks/task_e_684c8353c8f083239f41c72311fc5133