### PR TITLE
Enable manual coordinate entry

### DIFF
--- a/client/src/pages/admin.tsx
+++ b/client/src/pages/admin.tsx
@@ -754,6 +754,34 @@ export default function Admin() {
                               </FormItem>
                             )}
                           />
+                          <div className="grid grid-cols-2 gap-4">
+                            <FormField
+                              control={propertyForm.control}
+                              name="latitude"
+                              render={({ field }) => (
+                                <FormItem>
+                                  <FormLabel>Latitude</FormLabel>
+                                  <FormControl>
+                                    <Input {...field} placeholder="33.7490" />
+                                  </FormControl>
+                                  <FormMessage />
+                                </FormItem>
+                              )}
+                            />
+                            <FormField
+                              control={propertyForm.control}
+                              name="longitude"
+                              render={({ field }) => (
+                                <FormItem>
+                                  <FormLabel>Longitude</FormLabel>
+                                  <FormControl>
+                                    <Input {...field} placeholder="-84.3880" />
+                                  </FormControl>
+                                  <FormMessage />
+                                </FormItem>
+                              )}
+                            />
+                          </div>
                           <div className="flex justify-end space-x-2">
                             <Button
                               type="button"


### PR DESCRIPTION
## Summary
- add Latitude and Longitude fields to property form for manual map coordinates

## Testing
- `npm run check`
- `npm test` *(fails: Environment variable REPLIT_DOMAINS not provided)*

------
https://chatgpt.com/codex/tasks/task_e_684cbfc7a8588323b66533b4b0d1a57a