### PR TITLE
Allow 5 decimal coordinate precision

### DIFF
--- a/server/geocode.ts
+++ b/server/geocode.ts
@@ -16,7 +16,7 @@ export async function geocodeAddress(address: string): Promise<GeoResult | null>
 
     if (data.status === 'OK' && Array.isArray(data.results) && data.results.length > 0) {
       const { lat, lng } = data.results[0].geometry.location;
-      return { lat: String(lat), lon: String(lng) };
+      return { lat: lat.toFixed(5), lon: lng.toFixed(5) };
     }
 
     return null;

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -12,6 +12,13 @@ import { existsSync } from "fs";
 import sharp from "sharp";
 import { geocodeAddress } from "./geocode";
 
+function formatCoordinate(value: string | number | undefined): string | undefined {
+  if (value === undefined || value === null) return undefined;
+  const num = typeof value === 'number' ? value : parseFloat(value);
+  if (Number.isNaN(num)) return undefined;
+  return num.toFixed(5);
+}
+
 async function populateMissingCoordinates() {
   try {
     const props = await storage.getProperties();
@@ -119,6 +126,9 @@ export async function registerRoutes(app: Express): Promise<Server> {
         }
       }
 
+      validatedData.latitude = formatCoordinate(validatedData.latitude) as any;
+      validatedData.longitude = formatCoordinate(validatedData.longitude) as any;
+
       const property = await storage.createProperty(validatedData);
       res.status(201).json(property);
     } catch (error) {
@@ -151,6 +161,9 @@ export async function registerRoutes(app: Express): Promise<Server> {
           }
         }
       }
+
+      validatedData.latitude = formatCoordinate(validatedData.latitude) as any;
+      validatedData.longitude = formatCoordinate(validatedData.longitude) as any;
       const property = await storage.updateProperty(id, validatedData);
       
       if (!property) {


### PR DESCRIPTION
## Summary
- round coordinates returned from Google geocode API to five decimal places
- add helper to format coordinates when creating or updating properties

## Testing
- `npm test` *(fails: Environment variable REPLIT_DOMAINS not provided)*
- `node validate-deployment.js`


------
https://chatgpt.com/codex/tasks/task_e_684cc41bb608832391d458910718c70d