### PR TITLE
Fix lead submissions route

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -1,6 +1,7 @@
 import express, { type Request, Response, NextFunction } from "express";
 import { registerRoutes } from "./routes";
 import { setupVite, serveStatic, log } from "./vite";
+import { initStorage } from "./storage";
 import { config, validateProductionConfig, addSecurityHeaders } from "./config";
 
 const app = express();
@@ -49,6 +50,8 @@ app.use((req, res, next) => {
   try {
     // Validate production configuration
     validateProductionConfig();
+
+    await initStorage();
 
     const server = await registerRoutes(app);
 

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -14,7 +14,22 @@ import {
   type UpsertUser
 } from "@shared/schema";
 import { db } from "./db";
-import { eq } from "drizzle-orm";
+import { eq, sql } from "drizzle-orm";
+
+export async function initStorage() {
+  await db.execute(sql`
+    CREATE TABLE IF NOT EXISTS lead_submissions (
+      id serial PRIMARY KEY,
+      name text NOT NULL,
+      email text NOT NULL,
+      move_in_date timestamp,
+      desired_bedrooms text,
+      additional_info text,
+      contacted boolean NOT NULL DEFAULT false,
+      submitted_at timestamp DEFAULT now()
+    );
+  `);
+}
 
 export interface IStorage {
   // Properties


### PR DESCRIPTION
## Summary
- ensure lead submissions table exists during startup
- initialize storage before setting up routes

## Testing
- `npm run check`
- `npm test` *(fails: Environment variable REPLIT_DOMAINS not provided)*
- `node validate-deployment.js`

------
https://chatgpt.com/codex/tasks/task_e_684cc47fd94883239b6ef40af23596be