### PR TITLE
Format property coordinates to 5 decimals

### DIFF
--- a/client/src/components/map-section.tsx
+++ b/client/src/components/map-section.tsx
@@ -33,11 +33,11 @@ export default function MapSection({ cityFilter, setCityFilter, availabilityFilt
   const getCityCenter = (city: string) => {
     switch (city) {
       case "atlanta":
-        return { lat: 33.7490, lng: -84.3880 };
+        return { lat: 33.74900, lng: -84.38800 };
       case "dallas":
-        return { lat: 32.7767, lng: -96.7970 };
+        return { lat: 32.77670, lng: -96.79700 };
       default:
-        return { lat: 33.7490, lng: -84.3880 }; // Default to Atlanta
+        return { lat: 33.74900, lng: -84.38800 }; // Default to Atlanta
     }
   };
 

--- a/client/src/pages/admin.tsx
+++ b/client/src/pages/admin.tsx
@@ -762,7 +762,7 @@ export default function Admin() {
                                 <FormItem>
                                   <FormLabel>Latitude</FormLabel>
                                   <FormControl>
-                                    <Input {...field} placeholder="33.7490" />
+                                    <Input {...field} placeholder="33.74900" />
                                   </FormControl>
                                   <FormMessage />
                                 </FormItem>
@@ -775,7 +775,7 @@ export default function Admin() {
                                 <FormItem>
                                   <FormLabel>Longitude</FormLabel>
                                   <FormControl>
-                                    <Input {...field} placeholder="-84.3880" />
+                                    <Input {...field} placeholder="-84.38800" />
                                   </FormControl>
                                   <FormMessage />
                                 </FormItem>

--- a/server/storage-backup.ts
+++ b/server/storage-backup.ts
@@ -15,6 +15,13 @@ import {
 import { db } from "./db";
 import { eq } from "drizzle-orm";
 
+function formatCoordinate(value: string | number | null | undefined): string | undefined {
+  if (value === undefined || value === null) return undefined;
+  const num = typeof value === 'number' ? value : parseFloat(value);
+  if (Number.isNaN(num)) return undefined;
+  return num.toFixed(5);
+}
+
 export interface IStorage {
   // Properties
   getProperties(filters?: { city?: string; isAvailable?: boolean }): Promise<Property[]>;
@@ -72,8 +79,8 @@ export class DatabaseStorage implements IStorage {
         description: "Modern loft-style apartments in the heart of Midtown Atlanta",
         neighborhood: "Midtown",
         images: ["https://images.unsplash.com/photo-1522708323590-d24dbb6b0267?ixlib=rb-4.0.3&auto=format&fit=crop&w=800&h=600"],
-        latitude: "33.7701",
-        longitude: "-84.3870",
+        latitude: "33.77010",
+        longitude: "-84.38700",
         createdAt: new Date(),
       },
       {
@@ -89,8 +96,8 @@ export class DatabaseStorage implements IStorage {
         description: "Modern studio apartments with stunning city views",
         neighborhood: "Downtown",
         images: ["https://images.unsplash.com/photo-1484154218962-a197022b5858?ixlib=rb-4.0.3&auto=format&fit=crop&w=800&h=600"],
-        latitude: "32.7767",
-        longitude: "-96.7970",
+        latitude: "32.77670",
+        longitude: "-96.79700",
         createdAt: new Date(),
       }
     ];
@@ -144,8 +151,8 @@ export class DatabaseStorage implements IStorage {
       images: property.images || [],
       description: property.description || null,
       neighborhood: property.neighborhood || null,
-      latitude: property.latitude || null,
-      longitude: property.longitude || null,
+      latitude: formatCoordinate(property.latitude) || null,
+      longitude: formatCoordinate(property.longitude) || null,
       createdAt: new Date(),
     };
     this.properties.set(id, newProperty);
@@ -155,8 +162,13 @@ export class DatabaseStorage implements IStorage {
   async updateProperty(id: number, updates: Partial<InsertProperty>): Promise<Property | undefined> {
     const existing = this.properties.get(id);
     if (!existing) return undefined;
-    
-    const updated = { ...existing, ...updates };
+
+    const updated = {
+      ...existing,
+      ...updates,
+      latitude: updates.latitude !== undefined ? formatCoordinate(updates.latitude) : existing.latitude,
+      longitude: updates.longitude !== undefined ? formatCoordinate(updates.longitude) : existing.longitude,
+    };
     this.properties.set(id, updated);
     return updated;
   }

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -16,6 +16,13 @@ import {
 import { db } from "./db";
 import { eq } from "drizzle-orm";
 
+function formatCoordinate(value: string | number | null | undefined): string | undefined {
+  if (value === undefined || value === null) return undefined;
+  const num = typeof value === 'number' ? value : parseFloat(value);
+  if (Number.isNaN(num)) return undefined;
+  return num.toFixed(5);
+}
+
 export interface IStorage {
   // Properties
   getProperties(filters?: { city?: string; isAvailable?: boolean }): Promise<Property[]>;
@@ -103,7 +110,11 @@ export class DatabaseStorage implements IStorage {
   async createProperty(property: InsertProperty): Promise<Property> {
     const [newProperty] = await db
       .insert(properties)
-      .values(property)
+      .values({
+        ...property,
+        latitude: formatCoordinate(property.latitude) as any,
+        longitude: formatCoordinate(property.longitude) as any,
+      })
       .returning();
     return newProperty;
   }
@@ -111,7 +122,11 @@ export class DatabaseStorage implements IStorage {
   async updateProperty(id: number, updates: Partial<InsertProperty>): Promise<Property | undefined> {
     const [updated] = await db
       .update(properties)
-      .set(updates)
+      .set({
+        ...updates,
+        latitude: formatCoordinate(updates.latitude) as any,
+        longitude: formatCoordinate(updates.longitude) as any,
+      })
       .where(eq(properties.id, id))
       .returning();
     return updated || undefined;


### PR DESCRIPTION
## Summary
- keep coordinates at 5 decimal precision when formatting
- normalize and format coordinates for all existing properties
- ensure storage layers format coordinates on create/update
- update sample coordinates and default map locations
- update admin placeholders to 5-decimal examples

## Testing
- `npm run check`
- `npm test` *(fails: connect ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_684cc5ee4af48323b40f678664d1da86