### PR TITLE
Add landing page branding settings

### DIFF
--- a/client/src/components/admin/branding-form.tsx
+++ b/client/src/components/admin/branding-form.tsx
@@ -1,0 +1,79 @@
+import { useEffect } from "react";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Button } from "@/components/ui/button";
+import { Textarea } from "@/components/ui/textarea";
+import { apiRequest } from "@/lib/queryClient";
+import { insertBrandingSchema, type Branding } from "@shared/schema";
+import { useBranding } from "@/hooks/useBranding";
+
+export default function BrandingForm() {
+  const { data: branding } = useBranding();
+  const queryClient = useQueryClient();
+
+  const form = useForm<Partial<Branding>>({
+    resolver: zodResolver(insertBrandingSchema.partial()),
+    defaultValues: {},
+  });
+
+  useEffect(() => {
+    if (branding) {
+      form.reset(branding);
+    }
+  }, [branding, form]);
+
+  const mutation = useMutation({
+    mutationFn: async (values: Partial<Branding>) => {
+      return apiRequest("/api/branding", "PUT", values);
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["/api/branding"] });
+    },
+  });
+
+  return (
+    <form
+      onSubmit={form.handleSubmit((v) => mutation.mutate(v))}
+      className="space-y-4 max-w-xl"
+    >
+      <div>
+        <Label>Company Name</Label>
+        <Input {...form.register("companyName")} />
+      </div>
+      <div>
+        <Label>Logo URL</Label>
+        <Input {...form.register("logoUrl")} />
+      </div>
+      <div>
+        <Label>Primary Color</Label>
+        <Input type="color" {...form.register("primaryColor")} />
+      </div>
+      <div>
+        <Label>Secondary Color</Label>
+        <Input type="color" {...form.register("secondaryColor")} />
+      </div>
+      <div>
+        <Label>Cities (comma separated)</Label>
+        <Input {...form.register("cities", { setValueAs: v => v.split(',').map((c: string) => c.trim()).filter(Boolean) })} />
+      </div>
+      <div>
+        <Label>Header</Label>
+        <Input {...form.register("header")} />
+      </div>
+      <div>
+        <Label>Subtitle</Label>
+        <Textarea {...form.register("subtitle")} />
+      </div>
+      <div>
+        <Label>Footer Text</Label>
+        <Textarea {...form.register("footerText")} />
+      </div>
+      <Button type="submit" disabled={mutation.isPending} className="bg-primary text-white hover:bg-primary/90">
+        Save Branding
+      </Button>
+    </form>
+  );
+}

--- a/client/src/components/footer.tsx
+++ b/client/src/components/footer.tsx
@@ -1,12 +1,14 @@
 import { Link } from "wouter";
+import { useBranding } from "@/hooks/useBranding";
 
 export default function Footer() {
+  const { data: branding } = useBranding();
   return (
     <footer className="bg-neutral text-white py-12">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="grid grid-cols-1 md:grid-cols-4 gap-8">
           <div className="md:col-span-2">
-            <div className="text-2xl font-bold mb-4">UrbanLiving</div>
+            <div className="text-2xl font-bold mb-4">{branding?.companyName || "UrbanLiving"}</div>
             <p className="text-gray-300 mb-6 max-w-md">Locally owned and managed rental properties.</p>
             
           </div>
@@ -39,7 +41,11 @@ export default function Footer() {
         </div>
         
         <div className="border-t border-gray-600 mt-8 pt-8 text-center text-gray-300">
-          <p>&copy; 2024 UrbanLiving. All rights reserved. | <a href="#privacy" className="hover:text-white transition-colors">Privacy Policy</a> | <a href="#terms" className="hover:text-white transition-colors">Terms of Service</a></p>
+          <p>
+            &copy; 2024 {branding?.companyName || "UrbanLiving"}. All rights reserved. |
+            <a href="#privacy" className="hover:text-white transition-colors">Privacy Policy</a> |
+            <a href="#terms" className="hover:text-white transition-colors">Terms of Service</a>
+          </p>
         </div>
       </div>
     </footer>

--- a/client/src/components/navigation.tsx
+++ b/client/src/components/navigation.tsx
@@ -3,10 +3,12 @@ import { Link, useLocation } from "wouter";
 import { Button } from "@/components/ui/button";
 import { Sheet, SheetContent, SheetTrigger } from "@/components/ui/sheet";
 import { Menu } from "lucide-react";
+import { useBranding } from "@/hooks/useBranding";
 
 export default function Navigation() {
   const [location] = useLocation();
   const [isOpen, setIsOpen] = useState(false);
+  const { data: branding } = useBranding();
 
   const navItems = [
     { href: "/", label: "Properties" },
@@ -18,7 +20,9 @@ export default function Navigation() {
         <div className="flex justify-between items-center h-16">
           <div className="flex items-center">
             <Link href="/">
-              <div className="text-xl font-bold text-primary cursor-pointer">UrbanLiving</div>
+              <div className="text-xl font-bold cursor-pointer" style={{ color: branding?.primaryColor || "#2563eb" }}>
+                {branding?.companyName || "UrbanLiving"}
+              </div>
             </Link>
           </div>
           

--- a/client/src/hooks/useBranding.ts
+++ b/client/src/hooks/useBranding.ts
@@ -1,0 +1,8 @@
+import { useQuery } from "@tanstack/react-query";
+import type { Branding } from "@shared/schema";
+
+export function useBranding() {
+  return useQuery<Branding | null>({
+    queryKey: ["/api/branding"],
+  });
+}

--- a/client/src/pages/admin.tsx
+++ b/client/src/pages/admin.tsx
@@ -13,6 +13,7 @@ import { Switch } from "@/components/ui/switch";
 import { Badge } from "@/components/ui/badge";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Copy, Share2 } from "lucide-react";
+import BrandingForm from "@/components/admin/branding-form";
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from "@/components/ui/dialog";
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
 import { useForm } from "react-hook-form";
@@ -487,7 +488,7 @@ export default function Admin() {
       </div>
 
         <Tabs defaultValue="properties" className="space-y-6">
-          <TabsList className="grid w-full grid-cols-2 bg-gray-100 rounded-lg p-1">
+          <TabsList className="grid w-full grid-cols-3 bg-gray-100 rounded-lg p-1">
             <TabsTrigger value="properties" className="flex items-center gap-2 text-gray-600 data-[state=active]:bg-white data-[state=active]:text-blue-600 data-[state=active]:shadow-sm">
               <Building2 className="w-4 h-4" />
               Properties & Units
@@ -495,6 +496,10 @@ export default function Admin() {
             <TabsTrigger value="leads" className="flex items-center gap-2 text-gray-600 data-[state=active]:bg-white data-[state=active]:text-blue-600 data-[state=active]:shadow-sm">
               <Users className="w-4 h-4" />
               Lead Submissions
+            </TabsTrigger>
+            <TabsTrigger value="branding" className="flex items-center gap-2 text-gray-600 data-[state=active]:bg-white data-[state=active]:text-blue-600 data-[state=active]:shadow-sm">
+              <Building2 className="w-4 h-4" />
+              Branding
             </TabsTrigger>
           </TabsList>
 
@@ -1284,6 +1289,9 @@ export default function Admin() {
                 </div>
               </>
             )}
+          </TabsContent>
+          <TabsContent value="branding" className="space-y-6">
+            <BrandingForm />
           </TabsContent>
         </Tabs>
       </div>

--- a/client/src/pages/landing.tsx
+++ b/client/src/pages/landing.tsx
@@ -1,8 +1,10 @@
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Building, Users, Shield, Zap } from "lucide-react";
+import { useBranding } from "@/hooks/useBranding";
 
 export default function Landing() {
+  const { data: branding } = useBranding();
   const handleLogin = () => {
     window.location.href = "/api/login";
   };
@@ -13,10 +15,16 @@ export default function Landing() {
       <header className="border-b bg-white/80 backdrop-blur-sm dark:bg-gray-800/80">
         <div className="container mx-auto px-4 py-4 flex justify-between items-center">
           <div className="flex items-center space-x-2">
-            <Building className="h-8 w-8 text-blue-600" />
-            <span className="text-2xl font-bold text-gray-900 dark:text-white">UrbanLiving</span>
+            <Building className="h-8 w-8" style={{ color: branding?.primaryColor || "#2563eb" }} />
+            <span className="text-2xl font-bold text-gray-900 dark:text-white">
+              {branding?.companyName || "UrbanLiving"}
+            </span>
           </div>
-          <Button onClick={handleLogin} className="bg-blue-600 hover:bg-blue-700">
+          <Button
+            onClick={handleLogin}
+            style={{ backgroundColor: branding?.primaryColor || "#2563eb" }}
+            className="hover:opacity-90"
+          >
             Sign In
           </Button>
         </div>
@@ -25,13 +33,17 @@ export default function Landing() {
       <main className="container mx-auto px-4 py-16">
         <div className="text-center max-w-4xl mx-auto mb-16">
           <h1 className="text-5xl font-bold text-gray-900 dark:text-white mb-6">
-            Modern Property Management for Urban Markets
+            {branding?.header || "Modern Property Management for Urban Markets"}
           </h1>
-          <p className="text-xl text-gray-600 dark:text-gray-300 mb-8">Streamline your rental property marketing operations with our comprehensive platform designed for small and family-owned real estate businesses.</p>
-          <Button 
+          <p className="text-xl text-gray-600 dark:text-gray-300 mb-8">
+            {branding?.subtitle ||
+              "Streamline your rental property marketing operations with our comprehensive platform designed for small and family-owned real estate businesses."}
+          </p>
+          <Button
             onClick={handleLogin}
-            size="lg" 
-            className="bg-blue-600 hover:bg-blue-700 text-lg px-8 py-3"
+            size="lg"
+            style={{ backgroundColor: branding?.primaryColor || "#2563eb" }}
+            className="hover:opacity-90 text-lg px-8 py-3"
           >
             Get Started
           </Button>
@@ -94,12 +106,13 @@ export default function Landing() {
             Ready to Transform Your Property Management?
           </h2>
           <p className="text-lg text-gray-600 dark:text-gray-300 mb-6">
-            Join property managers who trust UrbanLiving to streamline their operations
+            Join property managers who trust {branding?.companyName || "UrbanLiving"} to streamline their operations
           </p>
-          <Button 
+          <Button
             onClick={handleLogin}
-            size="lg" 
-            className="bg-blue-600 hover:bg-blue-700 text-lg px-8 py-3"
+            size="lg"
+            style={{ backgroundColor: branding?.primaryColor || "#2563eb" }}
+            className="hover:opacity-90 text-lg px-8 py-3"
           >
             Sign In to Continue
           </Button>

--- a/client/src/pages/public-home.tsx
+++ b/client/src/pages/public-home.tsx
@@ -2,6 +2,7 @@ import { Button } from "@/components/ui/button";
 import { Building } from "lucide-react";
 import { Link } from "wouter";
 import { useState } from "react";
+import { useBranding } from "@/hooks/useBranding";
 import MapSection from "@/components/map-section";
 import PropertyGrid from "@/components/property-grid";
 import ApartmentFinder from "@/components/apartment-finder";
@@ -9,6 +10,7 @@ import NeighborhoodSection from "@/components/neighborhood-section";
 import Footer from "@/components/footer";
 
 export default function PublicHome() {
+  const { data: branding } = useBranding();
   const [cityFilter, setCityFilter] = useState<string>("atlanta");
   const [availabilityFilter, setAvailabilityFilter] = useState<boolean>(true);
 
@@ -17,11 +19,15 @@ export default function PublicHome() {
       <header className="bg-white border-b shadow-sm dark:bg-gray-800 dark:border-gray-700">
         <div className="container mx-auto px-4 py-4 flex justify-between items-center">
           <div className="flex items-center space-x-2">
-            <Building className="h-8 w-8 text-blue-600" />
-            <span className="text-2xl font-bold text-gray-900 dark:text-white">UrbanLiving</span>
+            <Building className="h-8 w-8" style={{ color: branding?.primaryColor || "#2563eb" }} />
+            <span className="text-2xl font-bold text-gray-900 dark:text-white">
+              {branding?.companyName || "UrbanLiving"}
+            </span>
           </div>
           <Link href="/">
-            <Button size="sm">Sign In</Button>
+            <Button size="sm" style={{ backgroundColor: branding?.primaryColor || "#2563eb" }} className="hover:opacity-90 text-white">
+              Sign In
+            </Button>
           </Link>
         </div>
       </header>

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -3,7 +3,7 @@ import express from "express";
 import { createServer, type Server } from "http";
 import { storage } from "./storage";
 import { setupAuth, isAuthenticated } from "./replitAuth";
-import { insertPropertySchema, insertUnitSchema, insertLeadSubmissionSchema } from "@shared/schema";
+import { insertPropertySchema, insertUnitSchema, insertLeadSubmissionSchema, insertBrandingSchema } from "@shared/schema";
 import { z } from "zod";
 import multer from "multer";
 import path from "path";
@@ -67,6 +67,28 @@ export async function registerRoutes(app: Express): Promise<Server> {
 
   // Serve photo files statically
   app.use('/photos', express.static('photos'));
+
+  app.get('/api/branding', async (req, res) => {
+    try {
+      const brandingData = await storage.getBranding();
+      res.json(brandingData || null);
+    } catch (error) {
+      res.status(500).json({ message: 'Failed to fetch branding' });
+    }
+  });
+
+  app.put('/api/branding', isAuthenticated, async (req, res) => {
+    try {
+      const validated = insertBrandingSchema.partial().parse(req.body);
+      const brandingData = await storage.updateBranding(validated);
+      res.json(brandingData);
+    } catch (error) {
+      if (error instanceof z.ZodError) {
+        return res.status(400).json({ message: 'Invalid branding data', errors: error.errors });
+      }
+      res.status(500).json({ message: 'Failed to update branding' });
+    }
+  });
   // Properties routes
   app.get("/api/properties", async (req, res) => {
     try {

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -5,13 +5,16 @@ import {
   users, 
   type Property, 
   type Unit, 
-  type LeadSubmission, 
+  type LeadSubmission,
   type User,
   type InsertProperty,
   type InsertUnit,
   type InsertLeadSubmission,
   type InsertUser,
-  type UpsertUser
+  type UpsertUser,
+  branding,
+  type Branding,
+  type InsertBranding
 } from "@shared/schema";
 import { db } from "./db";
 import { eq } from "drizzle-orm";
@@ -38,6 +41,10 @@ export interface IStorage {
   // Users (required for Replit Auth)
   getUser(id: string): Promise<User | undefined>;
   upsertUser(user: UpsertUser): Promise<User>;
+
+  // Branding
+  getBranding(): Promise<Branding | undefined>;
+  updateBranding(data: InsertBranding): Promise<Branding>;
 }
 
 export class DatabaseStorage implements IStorage {
@@ -178,6 +185,25 @@ export class DatabaseStorage implements IStorage {
       .where(eq(leadSubmissions.id, id))
       .returning();
     return updated || undefined;
+  }
+
+  async getBranding(): Promise<Branding | undefined> {
+    const [record] = await db.select().from(branding).limit(1);
+    return record || undefined;
+  }
+
+  async updateBranding(data: InsertBranding): Promise<Branding> {
+    const existing = await this.getBranding();
+    if (existing) {
+      const [updated] = await db
+        .update(branding)
+        .set(data)
+        .where(eq(branding.id, existing.id))
+        .returning();
+      return updated;
+    }
+    const [created] = await db.insert(branding).values(data).returning();
+    return created;
   }
 }
 

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -85,6 +85,22 @@ export const insertUserSchema = createInsertSchema(users).omit({
   updatedAt: true,
 });
 
+export const branding = pgTable("branding", {
+  id: serial("id").primaryKey(),
+  companyName: text("company_name").notNull().default("UrbanLiving"),
+  logoUrl: text("logo_url"),
+  primaryColor: text("primary_color").default("#2563eb"),
+  secondaryColor: text("secondary_color").default("#4f46e5"),
+  cities: text("cities").array().default([]),
+  header: text("header"),
+  subtitle: text("subtitle"),
+  footerText: text("footer_text"),
+});
+
+export const insertBrandingSchema = createInsertSchema(branding).omit({
+  id: true,
+});
+
 export type Property = typeof properties.$inferSelect;
 export type InsertProperty = z.infer<typeof insertPropertySchema>;
 export type Unit = typeof units.$inferSelect;
@@ -94,3 +110,5 @@ export type InsertLeadSubmission = z.infer<typeof insertLeadSubmissionSchema>;
 export type User = typeof users.$inferSelect;
 export type InsertUser = z.infer<typeof insertUserSchema>;
 export type UpsertUser = typeof users.$inferInsert;
+export type Branding = typeof branding.$inferSelect;
+export type InsertBranding = z.infer<typeof insertBrandingSchema>;


### PR DESCRIPTION
## Summary
- allow admins to manage site branding
- support branding table in schema
- expose `/api/branding` GET/PUT routes
- add React hook and admin form for branding
- render branding data on landing and public pages

## Testing
- `npm run check`
- `npm test` *(fails: Environment variable REPLIT_DOMAINS not provided)*

------
https://chatgpt.com/codex/tasks/task_e_684cc52569188323a27d68368bb9e5b9