### PR TITLE
Fix unit availability date toggle

### DIFF
--- a/client/src/pages/admin.tsx
+++ b/client/src/pages/admin.tsx
@@ -172,6 +172,14 @@ export default function Admin() {
     },
   });
 
+  const isAvailableWatch = unitForm.watch("isAvailable");
+
+  useEffect(() => {
+    if (!isAvailableWatch) {
+      unitForm.setValue("availableDate", "");
+    }
+  }, [isAvailableWatch]);
+
   // Mutations with enhanced error handling
   const createPropertyMutation = useMutation({
     mutationFn: async (data: any) => {
@@ -1097,19 +1105,21 @@ export default function Admin() {
                         </FormItem>
                       )}
                     />
-                    <FormField
-                      control={unitForm.control}
-                      name="availableDate"
-                      render={({ field }) => (
-                        <FormItem>
-                          <FormLabel>Available Date</FormLabel>
-                          <FormControl>
-                            <Input type="date" {...field} />
-                          </FormControl>
-                          <FormMessage />
-                        </FormItem>
-                      )}
-                    />
+                    {isAvailableWatch && (
+                      <FormField
+                        control={unitForm.control}
+                        name="availableDate"
+                        render={({ field }) => (
+                          <FormItem>
+                            <FormLabel>Available Date</FormLabel>
+                            <FormControl>
+                              <Input type="date" {...field} />
+                            </FormControl>
+                            <FormMessage />
+                          </FormItem>
+                        )}
+                      />
+                    )}
                     <FormField
                       control={unitForm.control}
                       name="isAvailable"


### PR DESCRIPTION
## Summary
- hide available date input when unit is not marked as available
- clear available date whenever the toggle is off

## Testing
- `npm run check`
- `npm test` *(fails: Environment variable `REPLIT_DOMAINS` not provided)*

------
https://chatgpt.com/codex/tasks/task_e_684da8f7a34083238b12a035b4baaa17