### PR TITLE
Move bed/bath data to units

### DIFF
--- a/client/src/components/map-section.tsx
+++ b/client/src/components/map-section.tsx
@@ -175,7 +175,7 @@ export default function MapSection({ cityFilter, setCityFilter, availabilityFilt
               ${property.address}, ${property.city}, ${property.state}
             </p>
             <p style="margin: 0 0 8px 0; color: #666; font-size: 13px;">
-              ${property.bedrooms === 0 ? 'Studio' : `${property.bedrooms} bed`} • ${property.bathrooms} bath • ${property.totalUnits} units
+              ${property.totalUnits === 1 ? `${property.bedrooms === 0 ? 'Studio' : `${property.bedrooms} bed`} • ${property.bathrooms} bath • ` : ''}${property.totalUnits} units
             </p>
             <button onclick="window.location.href='/property/${property.id}'" 
               style="background: #2D5AA0; color: white; border: none; padding: 6px 12px; border-radius: 4px; cursor: pointer; font-size: 13px;">
@@ -279,7 +279,7 @@ export default function MapSection({ cityFilter, setCityFilter, availabilityFilt
                     <p className="text-xs text-gray-500 mb-3">{property.neighborhood}</p>
                     <div className="flex justify-between items-center">
                       <span className="text-xs bg-gray-100 px-2 py-1 rounded">
-                        {property.bedrooms} bed • {property.bathrooms} bath
+                        {property.totalUnits === 1 ? `${property.bedrooms} bed • ${property.bathrooms} bath` : `${property.totalUnits} units`}
                       </span>
                       <Button size="sm" variant="outline" className="text-xs h-7">
                         View Details

--- a/client/src/pages/admin.tsx
+++ b/client/src/pages/admin.tsx
@@ -165,6 +165,8 @@ export default function Admin() {
     defaultValues: {
       propertyId: 0,
       unitNumber: "",
+      bedrooms: 0,
+      bathrooms: "",
       isAvailable: false,
       availableDate: "",
       rent: 0,
@@ -367,6 +369,8 @@ export default function Admin() {
         ...data,
         availableDate: data.availableDate ? new Date(data.availableDate).toISOString() : null,
         rent: data.rent ? Math.round(data.rent * 100) : null,
+        bedrooms: parseInt(data.bedrooms) || 0,
+        bathrooms: data.bathrooms,
       };
 
       if (editingUnit) {
@@ -410,6 +414,8 @@ export default function Admin() {
       unitForm.reset({
         ...unit,
         propertyId: unit.propertyId,
+        bedrooms: unit.bedrooms,
+        bathrooms: unit.bathrooms,
         availableDate: unit.availableDate ? new Date(unit.availableDate).toISOString().split('T')[0] : "",
         rent: unit.rent ? unit.rent / 100 : 0,
         images: (unit.images as any) || [],
@@ -419,6 +425,8 @@ export default function Admin() {
       unitForm.reset({
         propertyId: propertyId || 0,
         unitNumber: "",
+        bedrooms: 0,
+        bathrooms: "",
         isAvailable: true,
         availableDate: "",
         rent: 0,
@@ -843,7 +851,9 @@ export default function Admin() {
                                         <MapPin className="w-4 h-4" />
                                         {property.address}, {property.city}, {property.state}
                                       </span>
-                                      <span>{property.bedrooms} bed • {property.bathrooms} bath</span>
+                                      {property.totalUnits === 1 && (
+                                        <span>{`${property.bedrooms} bed • ${property.bathrooms} bath`}</span>
+                                      )}
                                       <span>{property.totalUnits} units</span>
                                     </div>
                                   </div>
@@ -985,12 +995,18 @@ export default function Admin() {
                                         <div className="space-y-2 text-sm">
                                           <div className="flex items-center justify-between">
                                             <span className="text-gray-600">Status:</span>
-                                            <Badge 
+                                            <Badge
                                               variant={unit.isAvailable ? "default" : "secondary"}
                                               className={unit.isAvailable ? "bg-green-100 text-green-700" : "bg-red-100 text-red-700"}
                                             >
                                               {unit.isAvailable ? "Available" : "Not Available"}
                                             </Badge>
+                                          </div>
+                                          <div className="flex items-center justify-between">
+                                            <span className="text-gray-600">Bed/Bath:</span>
+                                            <span className="text-gray-900">
+                                              {unit.bedrooms} bed • {unit.bathrooms} bath
+                                            </span>
                                           </div>
                                           
                                           {unit.rent && (
@@ -1074,6 +1090,36 @@ export default function Admin() {
                           <FormLabel>Unit Number *</FormLabel>
                           <FormControl>
                             <Input {...field} placeholder="101" />
+                          </FormControl>
+                          <FormMessage />
+                        </FormItem>
+                      )}
+                    />
+                    <FormField
+                      control={unitForm.control}
+                      name="bedrooms"
+                      render={({ field }) => (
+                        <FormItem>
+                          <FormLabel>Bedrooms *</FormLabel>
+                          <FormControl>
+                            <Input
+                              type="number"
+                              {...field}
+                              onChange={(e) => field.onChange(parseInt(e.target.value) || 0)}
+                            />
+                          </FormControl>
+                          <FormMessage />
+                        </FormItem>
+                      )}
+                    />
+                    <FormField
+                      control={unitForm.control}
+                      name="bathrooms"
+                      render={({ field }) => (
+                        <FormItem>
+                          <FormLabel>Bathrooms *</FormLabel>
+                          <FormControl>
+                            <Input {...field} placeholder="1" />
                           </FormControl>
                           <FormMessage />
                         </FormItem>

--- a/client/src/pages/property-detail.tsx
+++ b/client/src/pages/property-detail.tsx
@@ -145,14 +145,18 @@ export default function PropertyDetail() {
               </div>
             </div>
             <div className="flex items-center space-x-4">
-              <div className="flex items-center space-x-2">
-                <Bed className="w-4 h-4" />
-                <span>{property.bedrooms === 0 ? 'Studio' : `${property.bedrooms} bed`}</span>
-              </div>
-              <div className="flex items-center space-x-2">
-                <Bath className="w-4 h-4" />
-                <span>{property.bathrooms} bath</span>
-              </div>
+              {property.totalUnits === 1 && (
+                <>
+                  <div className="flex items-center space-x-2">
+                    <Bed className="w-4 h-4" />
+                    <span>{property.bedrooms === 0 ? 'Studio' : `${property.bedrooms} bed`}</span>
+                  </div>
+                  <div className="flex items-center space-x-2">
+                    <Bath className="w-4 h-4" />
+                    <span>{property.bathrooms} bath</span>
+                  </div>
+                </>
+              )}
               <div className="flex items-center space-x-2">
                 <Building className="w-4 h-4" />
                 <span>{property.totalUnits} units</span>
@@ -309,15 +313,18 @@ export default function PropertyDetail() {
                       <div key={unit.id} className="border rounded-lg p-4">
                         <div className="flex items-center justify-between mb-4">
                           <div className="flex items-center space-x-4">
-                            <span className="font-medium">Unit {unit.unitNumber}</span>
-                            <Badge variant={unit.isAvailable ? "default" : "secondary"}>
-                              {unit.isAvailable ? "Available" : "Leased"}
-                            </Badge>
-                            {unit.rent && (
-                              <span className="text-sm text-muted-foreground">
-                                ${(unit.rent / 100).toLocaleString()}/month
-                              </span>
-                            )}
+                          <span className="font-medium">Unit {unit.unitNumber}</span>
+                          <Badge variant={unit.isAvailable ? "default" : "secondary"}>
+                            {unit.isAvailable ? "Available" : "Leased"}
+                          </Badge>
+                          <span className="text-sm text-muted-foreground">
+                            {unit.bedrooms} bed • {unit.bathrooms} bath
+                          </span>
+                          {unit.rent && (
+                            <span className="text-sm text-muted-foreground">
+                              ${(unit.rent / 100).toLocaleString()}/month
+                            </span>
+                          )}
                           </div>
                           <div className="flex items-center space-x-4">
                             {unit.availableDate && (

--- a/server/storage-backup.ts
+++ b/server/storage-backup.ts
@@ -109,9 +109,9 @@ export class DatabaseStorage implements IStorage {
 
     // Sample units
     const sampleUnits: Unit[] = [
-      { id: 1, propertyId: 1, unitNumber: "101", isAvailable: true, availableDate: new Date(), rent: 185000, images: [] },
-      { id: 2, propertyId: 1, unitNumber: "102", isAvailable: false, availableDate: null, rent: 185000, images: [] },
-      { id: 3, propertyId: 2, unitNumber: "201", isAvailable: true, availableDate: new Date(), rent: 125000, images: [] },
+      { id: 1, propertyId: 1, unitNumber: "101", bedrooms: 2, bathrooms: "2", isAvailable: true, availableDate: new Date(), rent: 185000, images: [] },
+      { id: 2, propertyId: 1, unitNumber: "102", bedrooms: 2, bathrooms: "2", isAvailable: false, availableDate: null, rent: 185000, images: [] },
+      { id: 3, propertyId: 2, unitNumber: "201", bedrooms: 0, bathrooms: "1", isAvailable: true, availableDate: new Date(), rent: 125000, images: [] },
     ];
 
     sampleUnits.forEach(unit => {
@@ -188,13 +188,15 @@ export class DatabaseStorage implements IStorage {
 
   async createUnit(unit: InsertUnit): Promise<Unit> {
     const id = this.currentUnitId++;
-    const newUnit: Unit = { 
-      ...unit, 
+    const newUnit: Unit = {
+      ...unit,
       id,
       isAvailable: unit.isAvailable ?? false,
       images: unit.images || [],
       availableDate: unit.availableDate || null,
-      rent: unit.rent || null
+      rent: unit.rent || null,
+      bedrooms: unit.bedrooms ?? 0,
+      bathrooms: unit.bathrooms ?? ""
     };
     this.units.set(id, newUnit);
     return newUnit;

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -27,6 +27,8 @@ export const units = pgTable("units", {
   id: serial("id").primaryKey(),
   propertyId: integer("property_id").notNull(),
   unitNumber: text("unit_number").notNull(),
+  bedrooms: integer("bedrooms").notNull().default(0),
+  bathrooms: text("bathrooms").notNull().default(""),
   isAvailable: boolean("is_available").notNull().default(false),
   availableDate: timestamp("available_date"),
   rent: integer("rent"), // in cents


### PR DESCRIPTION
## Summary
- include bedrooms and bathrooms on units schema
- propagate new fields through backup storage
- update admin unit forms and displays
- conditionally show bedroom and bathroom info only for single-unit properties
- show new bed/bath data for each unit

## Testing
- `npm run check`
- `npm test` *(fails: Environment variable REPLIT_DOMAINS not provided)*
- `node validate-deployment.js`


------
https://chatgpt.com/codex/tasks/task_e_684da78d2158832386a9d429193e6e66