### PR TITLE
Add route tests

### DIFF
--- a/server/photo.routes.test.ts
+++ b/server/photo.routes.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+import { existsSync } from 'fs';
+
+process.env.DATABASE_URL = 'postgres://localhost/test';
+
+var mockStorage: any;
+var fsPromises: any;
+
+vi.mock('./storage', () => {
+  mockStorage = {
+    getProperty: vi.fn(),
+    getUnits: vi.fn(),
+  };
+  return { storage: mockStorage };
+});
+vi.mock('./db', () => ({ db: {} }));
+vi.mock('./geocode-update', () => ({ updateAllPropertyCoordinates: vi.fn() }));
+vi.mock('./replitAuth', () => ({
+  setupAuth: vi.fn(),
+  isAuthenticated: (_req: any, _res: any, next: any) => next(),
+}));
+vi.mock('fs/promises', () => {
+  fsPromises = {
+    unlink: vi.fn(),
+  };
+  return { default: fsPromises };
+});
+vi.mock('fs', () => ({ existsSync: vi.fn().mockReturnValue(false) }));
+
+import { registerRoutes } from './routes';
+
+let app: express.Express;
+
+beforeEach(async () => {
+  Object.values(mockStorage).forEach(fn => fn.mockReset && fn.mockReset());
+  fsPromises.unlink.mockReset();
+  app = express();
+  app.use(express.json());
+  await registerRoutes(app);
+});
+
+describe('photo routes', () => {
+  it('GET /api/photos/property/:id returns 404 when property missing', async () => {
+    mockStorage.getProperty.mockResolvedValue(undefined);
+    const res = await request(app).get('/api/photos/property/1');
+    expect(res.status).toBe(404);
+  });
+
+  it('GET /api/photos/property/:id success with empty arrays', async () => {
+    mockStorage.getProperty.mockResolvedValue({ id: 1, name: 'Prop', city: 'Town' });
+    mockStorage.getUnits.mockResolvedValue([]);
+    const res = await request(app).get('/api/photos/property/1');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ exterior: [], interior: [], amenities: [], units: {} });
+  });
+
+  it('DELETE /api/photos returns 400 without path', async () => {
+    const res = await request(app).delete('/api/photos').send({});
+    expect(res.status).toBe(400);
+  });
+
+  it('DELETE /api/photos returns 404 when file missing', async () => {
+    (existsSync as unknown as vi.Mock).mockReturnValue(false);
+    const res = await request(app).delete('/api/photos').send({ path: 'x.jpg' });
+    expect(res.status).toBe(404);
+  });
+
+  it('DELETE /api/photos success', async () => {
+    (existsSync as unknown as vi.Mock).mockReturnValue(true);
+    fsPromises.unlink.mockResolvedValue(undefined);
+    const res = await request(app).delete('/api/photos').send({ path: 'x.jpg' });
+    expect(res.status).toBe(200);
+    expect(fsPromises.unlink).toHaveBeenCalled();
+  });
+});

--- a/server/property.routes.test.ts
+++ b/server/property.routes.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+
+process.env.DATABASE_URL = 'postgres://localhost/test';
+
+var mockStorage: any;
+vi.mock('./storage', () => {
+  mockStorage = {
+    getProperties: vi.fn(),
+    getProperty: vi.fn(),
+    createProperty: vi.fn(),
+    updateProperty: vi.fn(),
+    deleteProperty: vi.fn(),
+    getUnits: vi.fn(),
+  };
+  return { storage: mockStorage };
+});
+vi.mock('./db', () => ({ db: {} }));
+vi.mock('./geocode-update', () => ({ updateAllPropertyCoordinates: vi.fn() }));
+vi.mock('./replitAuth', () => ({
+  setupAuth: vi.fn(),
+  isAuthenticated: (_req: any, _res: any, next: any) => next(),
+}));
+vi.mock('./geocode', () => ({ geocodeAddress: vi.fn().mockResolvedValue({ lat: '1', lon: '1' }) }));
+
+import { registerRoutes } from './routes';
+
+let app: express.Express;
+
+beforeEach(async () => {
+  Object.values(mockStorage).forEach(fn => fn.mockReset && fn.mockReset());
+  app = express();
+  app.use(express.json());
+  await registerRoutes(app);
+});
+
+describe('property routes', () => {
+  it('GET /api/properties returns properties list', async () => {
+    mockStorage.getProperties.mockResolvedValue([{ id: 1, name: 'A' }]);
+    const res = await request(app).get('/api/properties');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual([{ id: 1, name: 'A' }]);
+  });
+
+  it('GET /api/properties handles failure', async () => {
+    mockStorage.getProperties.mockRejectedValue(new Error('fail'));
+    const res = await request(app).get('/api/properties');
+    expect(res.status).toBe(500);
+  });
+
+  it('POST /api/properties creates property', async () => {
+    const data = {
+      name: 'Prop',
+      address: '123 St',
+      city: 'Town',
+      state: 'TS',
+      zipCode: '00000',
+      bedrooms: 1,
+      bathrooms: '1',
+      totalUnits: 1,
+    };
+    mockStorage.createProperty.mockResolvedValue({ id: 2, ...data });
+    const res = await request(app).post('/api/properties').send(data);
+    expect(res.status).toBe(201);
+    expect(res.body).toEqual({ id: 2, ...data });
+  });
+
+  it('POST /api/properties returns 400 for invalid data', async () => {
+    const res = await request(app).post('/api/properties').send({});
+    expect(res.status).toBe(400);
+  });
+
+  it('GET /api/properties/:id returns 404 when not found', async () => {
+    mockStorage.getProperty.mockResolvedValue(undefined);
+    const res = await request(app).get('/api/properties/1');
+    expect(res.status).toBe(404);
+  });
+
+  it('GET /api/properties/:id returns 400 for invalid id', async () => {
+    const res = await request(app).get('/api/properties/abc');
+    expect(res.status).toBe(400);
+  });
+});

--- a/server/routes.test.ts
+++ b/server/routes.test.ts
@@ -2,6 +2,8 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 import express from 'express';
 import request from 'supertest';
 
+process.env.DATABASE_URL = 'postgres://localhost/test';
+
 vi.mock('./storage', () => {
   return {
     storage: {
@@ -10,6 +12,12 @@ vi.mock('./storage', () => {
     }
   };
 });
+vi.mock('./db', () => ({ db: {} }));
+vi.mock('./geocode-update', () => ({ updateAllPropertyCoordinates: vi.fn() }));
+vi.mock('./replitAuth', () => ({
+  setupAuth: vi.fn(),
+  isAuthenticated: (_req: any, _res: any, next: any) => next(),
+}));
 
 import { registerRoutes } from './routes';
 import { storage } from './storage';

--- a/server/unit.routes.test.ts
+++ b/server/unit.routes.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+
+process.env.DATABASE_URL = 'postgres://localhost/test';
+
+var mockStorage: any;
+vi.mock('./storage', () => {
+  mockStorage = {
+    getUnits: vi.fn(),
+    createUnit: vi.fn(),
+    updateUnit: vi.fn(),
+    deleteUnit: vi.fn(),
+    getProperties: vi.fn(),
+    getProperty: vi.fn(),
+  };
+  return { storage: mockStorage };
+});
+vi.mock('./db', () => ({ db: {} }));
+vi.mock('./geocode-update', () => ({ updateAllPropertyCoordinates: vi.fn() }));
+vi.mock('./replitAuth', () => ({
+  setupAuth: vi.fn(),
+  isAuthenticated: (_req: any, _res: any, next: any) => next(),
+}));
+
+import { registerRoutes } from './routes';
+
+let app: express.Express;
+
+beforeEach(async () => {
+  Object.values(mockStorage).forEach(fn => fn.mockReset && fn.mockReset());
+  app = express();
+  app.use(express.json());
+  await registerRoutes(app);
+});
+
+describe('unit routes', () => {
+  it('GET /api/units returns units filtered by property', async () => {
+    mockStorage.getUnits.mockResolvedValue([{ id: 1, propertyId: 1 }]);
+    const res = await request(app).get('/api/units?propertyId=1');
+    expect(res.status).toBe(200);
+    expect(mockStorage.getUnits).toHaveBeenCalledWith(1);
+    expect(res.body).toEqual([{ id: 1, propertyId: 1 }]);
+  });
+
+  it('GET /api/units returns 400 for invalid property id', async () => {
+    const res = await request(app).get('/api/units?propertyId=abc');
+    expect(res.status).toBe(400);
+  });
+
+  it('POST /api/units creates unit', async () => {
+    const payload = {
+      propertyId: 1,
+      unitNumber: '1A',
+      bedrooms: 1,
+      bathrooms: '1',
+    };
+    mockStorage.createUnit.mockResolvedValue({ id: 2, ...payload });
+    const res = await request(app).post('/api/units').send(payload);
+    expect(res.status).toBe(201);
+    expect(res.body).toEqual({ id: 2, ...payload });
+  });
+
+  it('PUT /api/units/:id returns 404 when unit missing', async () => {
+    mockStorage.updateUnit.mockResolvedValue(undefined);
+    const res = await request(app).put('/api/units/1').send({ bedrooms: 2 });
+    expect(res.status).toBe(404);
+  });
+
+  it('DELETE /api/units/:id handles not found', async () => {
+    mockStorage.deleteUnit.mockResolvedValue(false);
+    const res = await request(app).delete('/api/units/1');
+    expect(res.status).toBe(404);
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for property routes
- add tests for unit routes
- add tests for photo routes
- mock DB and auth modules for server tests

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_684db409707c83238bfca0883e7a234f