### PR TITLE
Update branding colors globally

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -10,6 +10,7 @@ import PropertyDetail from "@/pages/property-detail";
 import Admin from "@/pages/admin";
 import PublicHome from "@/pages/public-home";
 import NotFound from "@/pages/not-found";
+import { useApplyBranding } from "@/hooks/useApplyBranding";
 
 function Router() {
   const { isAuthenticated, isLoading } = useAuth();
@@ -32,6 +33,7 @@ function Router() {
 }
 
 function App() {
+  useApplyBranding();
   return (
     <QueryClientProvider client={queryClient}>
       <TooltipProvider>

--- a/client/src/hooks/useApplyBranding.ts
+++ b/client/src/hooks/useApplyBranding.ts
@@ -1,0 +1,21 @@
+import { useEffect } from "react";
+import { useBranding } from "./useBranding";
+
+export function useApplyBranding() {
+  const { data: branding } = useBranding();
+
+  useEffect(() => {
+    if (branding?.primaryColor) {
+      document.documentElement.style.setProperty(
+        "--primary",
+        branding.primaryColor,
+      );
+    }
+    if (branding?.secondaryColor) {
+      document.documentElement.style.setProperty(
+        "--secondary",
+        branding.secondaryColor,
+      );
+    }
+  }, [branding?.primaryColor, branding?.secondaryColor]);
+}


### PR DESCRIPTION
## Summary
- apply branding colors to CSS variables
- use the new hook in App to update styling after branding changes

## Testing
- `npm run check`
- `npm test` (all tests passed)

------
https://chatgpt.com/codex/tasks/task_e_684f1ec6d3a8832398b6bfa31269c940