### PR TITLE
Add property thumbnails to admin

### DIFF
--- a/client/src/components/admin/property-thumbnail.tsx
+++ b/client/src/components/admin/property-thumbnail.tsx
@@ -1,0 +1,33 @@
+import { useQuery } from "@tanstack/react-query";
+import { apiRequest } from "@/lib/queryClient";
+import type { Property } from "@shared/schema";
+
+interface Props {
+  property: Property;
+}
+
+interface PhotoData {
+  exterior: string[];
+  interior: string[];
+  amenities: string[];
+}
+
+export default function PropertyThumbnail({ property }: Props) {
+  const { data } = useQuery<PhotoData>({
+    queryKey: ["/api/photos/property", property.id],
+    queryFn: () => apiRequest(`/api/photos/property/${property.id}`),
+    staleTime: 30_000,
+  });
+
+  const featured = data?.exterior?.[0] || data?.interior?.[0] || data?.amenities?.[0];
+
+  if (!featured) return null;
+
+  return (
+    <img
+      src={featured}
+      alt={`${property.name} photo`}
+      className="w-10 h-10 object-cover rounded-md border"
+    />
+  );
+}

--- a/client/src/pages/admin.tsx
+++ b/client/src/pages/admin.tsx
@@ -26,6 +26,7 @@ import { insertPropertySchema, insertUnitSchema } from "@shared/schema";
 import type { Property, Unit, LeadSubmission } from "@shared/schema";
 import Metrics from "@/components/admin/metrics";
 import SearchBox from "@/components/admin/search-box";
+import PropertyThumbnail from "@/components/admin/property-thumbnail";
 import { 
   Plus, 
   Edit, 
@@ -850,6 +851,7 @@ export default function Admin() {
                                   <div className="bg-blue-100 p-2 rounded-lg">
                                     <Building2 className="w-5 h-5 text-blue-600" />
                                   </div>
+                                  <PropertyThumbnail property={property} />
                                   <div>
                                     <CardTitle className="text-xl font-semibold text-gray-900">
                                       {property.name}


### PR DESCRIPTION
## Summary
- show property featured image alongside building icon on the admin properties list
- add `PropertyThumbnail` component to fetch photos

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684f1e7dd69c832382e992572dbd1a20