### PR TITLE
Switch public and admin paths

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -17,14 +17,14 @@ function Router() {
 
   return (
     <Switch>
-      <Route path="/public" component={PublicHome} />
+      <Route path="/" component={PublicHome} />
       <Route path="/property/:id" component={PropertyDetail} />
       {isLoading || !isAuthenticated ? (
-        <Route path="/" component={Landing} />
+        <Route path="/admin" component={Landing} />
       ) : (
         <>
-          <Route path="/" component={Home} />
-          <Route path="/admin" component={Admin} />
+          <Route path="/admin/dashboard" component={Admin} />
+          <Route path="/admin" component={Home} />
         </>
       )}
       <Route component={NotFound} />

--- a/client/src/pages/admin.tsx
+++ b/client/src/pages/admin.tsx
@@ -490,11 +490,11 @@ export default function Admin() {
               <CardTitle className="text-sm font-medium">Public Listing Link</CardTitle>
             </CardHeader>
             <CardContent className="flex items-center justify-between">
-              <span className="text-sm break-all">{window.location.origin + '/public'}</span>
+              <span className="text-sm break-all">{window.location.origin}</span>
               <Button
                 size="icon"
                 variant="ghost"
-                onClick={() => navigator.clipboard.writeText(window.location.origin + '/public')}
+                onClick={() => navigator.clipboard.writeText(window.location.origin)}
                 title="Copy link"
               >
                 <Copy className="w-4 h-4" />

--- a/client/src/pages/home.tsx
+++ b/client/src/pages/home.tsx
@@ -52,7 +52,7 @@ export default function Home() {
             </div>
             
             <div className="flex items-center space-x-4">
-              <Link href="/admin">
+              <Link href="/admin/dashboard">
                 <Button variant="outline" size="sm">
                   <Users className="w-4 h-4 mr-2" />
                   Admin Dashboard


### PR DESCRIPTION
## Summary
- route `/` to the public landing page
- serve admin landing on `/admin`
- move admin dashboard to `/admin/dashboard`
- update public link references
- update dashboard link in authenticated home page

## Testing
- `npm test`
- `node validate-deployment.js`


------
https://chatgpt.com/codex/tasks/task_e_68502fecca388323b61b7c74de9f397c