### PR TITLE
Add editable contact info in branding

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ The application uses PostgreSQL with these core tables:
 - `header`: Main heading text
 - `subtitle`: Subtitle text
 - `footerText`: Footer content
+- `contactInfo`: Contact information displayed in the footer
 
 ## API Endpoints
 

--- a/client/src/components/admin/branding-form.tsx
+++ b/client/src/components/admin/branding-form.tsx
@@ -25,6 +25,7 @@ export default function BrandingForm() {
       header: "",
       subtitle: "",
       footerText: "",
+      contactInfo: "",
     },
   });
 
@@ -87,6 +88,10 @@ export default function BrandingForm() {
       <div>
         <Label>Footer Text</Label>
         <Textarea {...form.register("footerText")} />
+      </div>
+      <div>
+        <Label>Contact Info (one item per line)</Label>
+        <Textarea {...form.register("contactInfo")} />
       </div>
       <Button type="submit" disabled={mutation.isPending} className="bg-primary text-white hover:bg-primary/90">
         Save Branding

--- a/client/src/components/footer.tsx
+++ b/client/src/components/footer.tsx
@@ -3,6 +3,13 @@ import { useBranding } from "@/hooks/useBranding";
 
 export default function Footer() {
   const { data: branding } = useBranding();
+  const contactItems = branding?.contactInfo
+    ? branding.contactInfo.split("\n").filter(Boolean)
+    : [
+        "Atlanta Office (404) 555-0123",
+        "Dallas Office (214) 555-0123",
+        "hello@urbanliving.com",
+      ];
   return (
     <footer className="bg-neutral text-white py-12">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
@@ -26,18 +33,9 @@ export default function Footer() {
           <div>
             <h3 className="text-lg font-semibold mb-4">Contact Info</h3>
             <ul className="space-y-2 text-gray-300">
-              <li>
-                <span className="block">Atlanta Office</span>
-                <span className="text-sm">(404) 555-0123</span>
-              </li>
-              <li>
-                <span className="block">Dallas Office</span>
-                <span className="text-sm">(214) 555-0123</span>
-              </li>
-              <li>
-                <span className="block">Email</span>
-                <span className="text-sm">hello@urbanliving.com</span>
-              </li>
+              {contactItems.map((item, idx) => (
+                <li key={idx}>{item}</li>
+              ))}
             </ul>
           </div>
         </div>

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -91,7 +91,8 @@ export async function initStorage() {
       cities text[],
       header text,
       subtitle text,
-      footer_text text
+      footer_text text,
+      contact_info text
     );
   `);
 }

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -97,6 +97,7 @@ export const branding = pgTable("branding", {
   header: text("header"),
   subtitle: text("subtitle"),
   footerText: text("footer_text"),
+  contactInfo: text("contact_info"),
 });
 
 export const insertBrandingSchema = createInsertSchema(branding).omit({


### PR DESCRIPTION
## Summary
- allow changing contact info in BrandingForm
- read `contactInfo` field in Footer
- store contact info in database schema
- document new column in README

## Testing
- `npm run check`
- `npm test`
- `node validate-deployment.js`
- `npm run db:push` *(fails: DATABASE_URL not set)*

------
https://chatgpt.com/codex/tasks/task_e_685033490ce48323a84bd3f2ca3774e4