### PR TITLE
Add property page lead form and map

### DIFF
--- a/client/src/components/lead-form-dialog.tsx
+++ b/client/src/components/lead-form-dialog.tsx
@@ -1,0 +1,197 @@
+import { useState } from 'react';
+import { useMutation } from '@tanstack/react-query';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import {
+  Form,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormControl,
+  FormMessage,
+} from '@/components/ui/form';
+import { Input } from '@/components/ui/input';
+import { Textarea } from '@/components/ui/textarea';
+import { Button } from '@/components/ui/button';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { useToast } from '@/hooks/use-toast';
+import { apiRequest } from '@/lib/queryClient';
+import { insertLeadSubmissionSchema } from '@shared/schema';
+import { z } from 'zod';
+
+interface LeadFormDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  defaultDate?: Date;
+}
+
+const formSchema = insertLeadSubmissionSchema.extend({
+  moveInDate: z.string().optional(),
+});
+
+export default function LeadFormDialog({
+  open,
+  onOpenChange,
+  defaultDate,
+}: LeadFormDialogProps) {
+  const { toast } = useToast();
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const form = useForm({
+    resolver: zodResolver(formSchema),
+    defaultValues: {
+      name: '',
+      email: '',
+      moveInDate: defaultDate
+        ? new Date(defaultDate).toISOString().slice(0, 10)
+        : '',
+      desiredBedrooms: '',
+      additionalInfo: '',
+    },
+  });
+
+  const submitMutation = useMutation({
+    mutationFn: async (data: z.infer<typeof formSchema>) => {
+      const submitData = {
+        ...data,
+        moveInDate: data.moveInDate ? new Date(data.moveInDate) : null,
+      };
+      return await apiRequest('/api/lead-submissions', 'POST', submitData);
+    },
+    onSuccess: () => {
+      toast({ title: 'Success', description: 'Your request has been sent.' });
+      form.reset();
+      setIsSubmitting(false);
+      onOpenChange(false);
+    },
+    onError: () => {
+      toast({
+        title: 'Error',
+        description: 'Failed to submit. Please try again.',
+        variant: 'destructive',
+      });
+      setIsSubmitting(false);
+    },
+  });
+
+  const onSubmit = (data: z.infer<typeof formSchema>) => {
+    setIsSubmitting(true);
+    submitMutation.mutate(data);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Request Information</DialogTitle>
+        </DialogHeader>
+        <Form {...form}>
+          <form onSubmit={form.handleSubmit(onSubmit)} className="grid gap-4">
+            <FormField
+              control={form.control}
+              name="name"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Name *</FormLabel>
+                  <FormControl>
+                    <Input {...field} placeholder="Your name" />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="email"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Email *</FormLabel>
+                  <FormControl>
+                    <Input
+                      type="email"
+                      {...field}
+                      placeholder="you@example.com"
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="moveInDate"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Desired Move-in Date</FormLabel>
+                  <FormControl>
+                    <Input type="date" {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="desiredBedrooms"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Desired Bedrooms</FormLabel>
+                  <FormControl>
+                    <Select
+                      onValueChange={field.onChange}
+                      defaultValue={field.value}
+                    >
+                      <SelectTrigger>
+                        <SelectValue placeholder="Select" />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="studio">Studio</SelectItem>
+                        <SelectItem value="1">1</SelectItem>
+                        <SelectItem value="2">2</SelectItem>
+                        <SelectItem value="3">3</SelectItem>
+                        <SelectItem value="4+">4+</SelectItem>
+                      </SelectContent>
+                    </Select>
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="additionalInfo"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Additional Information</FormLabel>
+                  <FormControl>
+                    <Textarea {...field} rows={3} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <Button
+              type="submit"
+              disabled={isSubmitting}
+              className="w-full bg-primary text-white"
+            >
+              {isSubmitting ? 'Submitting...' : 'Submit'}
+            </Button>
+          </form>
+        </Form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/client/src/components/property-map.tsx
+++ b/client/src/components/property-map.tsx
@@ -1,0 +1,92 @@
+import { useEffect, useRef, useState } from 'react';
+import { MapPin } from 'lucide-react';
+
+declare global {
+  interface Window {
+    initPropertyMap?: () => void;
+  }
+}
+
+interface PropertyMapProps {
+  latitude?: string | number | null;
+  longitude?: string | number | null;
+  name: string;
+}
+
+export default function PropertyMap({
+  latitude,
+  longitude,
+  name,
+}: PropertyMapProps) {
+  const mapRef = useRef<HTMLDivElement>(null);
+  const [loaded, setLoaded] = useState(false);
+  const [error, setError] = useState(false);
+
+  useEffect(() => {
+    if (!latitude || !longitude) return;
+
+    const lat = typeof latitude === 'string' ? parseFloat(latitude) : latitude;
+    const lng =
+      typeof longitude === 'string' ? parseFloat(longitude) : longitude;
+
+    if (Number.isNaN(lat) || Number.isNaN(lng)) return;
+
+    const init = () => {
+      try {
+        if (!window.google || !mapRef.current) {
+          throw new Error('Google Maps not available');
+        }
+        const map = new window.google.maps.Map(mapRef.current, {
+          center: { lat, lng },
+          zoom: 15,
+        });
+        new window.google.maps.Marker({
+          position: { lat, lng },
+          map,
+          title: name,
+        });
+        setLoaded(true);
+      } catch {
+        setError(true);
+      }
+    };
+
+    if (!window.google) {
+      const script = document.createElement('script');
+      script.src = `https://maps.googleapis.com/maps/api/js?key=${import.meta.env.VITE_GOOGLE_API_KEY || ''}&callback=initPropertyMap`;
+      script.async = true;
+      script.defer = true;
+      window.initPropertyMap = init;
+      script.onerror = () => setError(true);
+      document.head.appendChild(script);
+    } else {
+      init();
+    }
+
+    return () => {
+      if ((window as any).initPropertyMap) {
+        delete (window as any).initPropertyMap;
+      }
+    };
+  }, [latitude, longitude, name]);
+
+  if (!latitude || !longitude) {
+    return <p className="text-sm text-gray-500">Location not available</p>;
+  }
+
+  return (
+    <div className="relative h-64 w-full rounded-lg overflow-hidden bg-gray-100">
+      {!loaded && !error && (
+        <div className="absolute inset-0 flex items-center justify-center">
+          <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary" />
+        </div>
+      )}
+      {error && (
+        <div className="absolute inset-0 flex items-center justify-center text-gray-500">
+          <MapPin className="w-5 h-5 mr-2" /> Map unavailable
+        </div>
+      )}
+      <div ref={mapRef} className="h-full w-full" />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- show PhotoGallery hero on property page
- filter and sort available units
- add map showing property location
- allow scheduling tour/contact through lead form

## Testing
- `npm run check`
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_685033c190508323bca823ec34c4ef75